### PR TITLE
Skip GUID column when replacing

### DIFF
--- a/scripts/sync-all.sh
+++ b/scripts/sync-all.sh
@@ -26,6 +26,6 @@ if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
   cd ../ &&
   wp "@$TO" db export &&
   wp "@$FROM" db export - | wp "@$TO" db import - &&
-  wp "@$TO" search-replace "$FROMSITE" "$TOSITE" &&
+  wp "@$TO" search-replace "$FROMSITE" "$TOSITE" --skip-columns=guid &&
   rsync -az --progress "$FROMDIR" "$TODIR"
 fi

--- a/sync-db-from-prod.sh
+++ b/sync-db-from-prod.sh
@@ -5,7 +5,7 @@ then
     wp @development db reset --yes
     wp @production db export - > sql-dump-production.sql
     wp @development db import sql-dump-production.sql
-    wp @development search-replace https://imagewize.nl http://imagewizenl.dev
+    wp @development search-replace https://imagewize.nl http://imagewizenl.dev --skip-columns=guid
 else
     exit 0
 fi


### PR DESCRIPTION
The GUID field should never be changed, see https://codex.wordpress.org/Changing_The_Site_URL#Important_GUID_Note.
This is accomplished by passing `--skip-columns=guid` .